### PR TITLE
Fix SqsListener javadoc

### DIFF
--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/annotation/SqsListener.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/annotation/SqsListener.java
@@ -124,7 +124,7 @@ public @interface SqsListener {
 	String pollTimeoutSeconds() default "";
 
 	/**
-	 * The maximum amount of time to wait for a poll to SQS. If a value greater than 10 is provided, the result of
+	 * The maximum number of messages to poll from SQS. If a value greater than 10 is provided, the result of
 	 * multiple polls will be combined, which can be useful for
 	 * {@link io.awspring.cloud.sqs.listener.ListenerMode#BATCH}
 	 * @return the maximum messages per poll.


### PR DESCRIPTION
The current javadoc seems to be mistyped, referring to time instead of messages.

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
The current javadoc for `maxMessagesPerPoll` refers to a time setting while the configuration is for max messages per poll.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixing documentation.
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?
Not a code change

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
